### PR TITLE
fix merlin ddb

### DIFF
--- a/test/merlin_data.s
+++ b/test/merlin_data.s
@@ -1,0 +1,8 @@
+; merlin_data.s
+ db $12,$34,$56,$78
+ ddb $1234,$5678 ; double byte - big endian format.
+ dw $1234
+ da $1234
+ adr $123456
+ adrl $12345678
+


### PR DESCRIPTION
ddb generates a "double byte" which is actually a big-endian 16-bit number.
For relocation purposes, it has to be handled as 2 individual bytes with shifts to adjust it.